### PR TITLE
replaces cookies to save ingredients with local storage

### DIFF
--- a/src/pages/function/HandleIngredient.js
+++ b/src/pages/function/HandleIngredient.js
@@ -1,6 +1,5 @@
 import React, { startTransition, useCallback } from 'react';
 import WhatCanICookAPI from '../api/WhatCanICookAPI.js';
-import Cookies from 'js-cookie';
 
 const HandleIngredientInput = ({ ingredientValue, setIngredientValue, setMessage, setRecipes }) => {
   const fetchRecipes = useCallback(async (ingredient) => {
@@ -36,8 +35,7 @@ const HandleIngredientInput = ({ ingredientValue, setIngredientValue, setMessage
       if (event.key === "Enter") {
         startTransition(() => {
           if (ingredientValue) {
-            Cookies.set('ingredient', ingredientValue, { expires: 1 });
-            // Call the memoized fetchRecipes function
+            localStorage.setItem("ingredients", ingredientValue)
             fetchRecipes(ingredientValue);
           } else {
             setMessage("");

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import React, { Suspense, useState, useEffect } from 'react';
-import Cookies from 'js-cookie';
+// import Cookies from 'js-cookie';
 
 const HandleIngredientInputComponent = React.lazy(() => import('./function/HandleIngredient.js'));
 const LazyRecipesList = React.lazy(() => import('./recipes/list.js'));
@@ -10,8 +10,7 @@ const Home = () => {
   const [message, setMessage] = useState("");
 
   useEffect(() => {
-    const savedIngredient = Cookies.get('ingredient');
-
+    const savedIngredient = localStorage.getItem("ingredients");
     if (savedIngredient) {
       setIngredientValue(savedIngredient);
     }


### PR DESCRIPTION
# Moving from cookies to local storage reasons:
1. No HTTP Overhead: Cookies are sent with every HTTP request, which can add unnecessary overhead, especially when storing large amounts of data. Local storage, on the other hand, is only accessible via JavaScript and does not add overhead to requests.

2. Simplified Security Concerns: Local storage data is not automatically sent to the server, so it's easier to control access to sensitive information, unlike cookies that can be accessed by both the client and server. This reduces the risk of leaking user data unintentionally.

3. Persistent Storage: Unlike cookies, which can have expiration dates or be cleared by the browser, local storage data remains available until explicitly deleted by the user or application. This makes it better for long-term storage.

# Why not session? Local storage over session storage:
1. Persistence Across Sessions: Local storage persists even after the browser is closed and reopened, which is ideal for remembering ingredients between user sessions. Session storage only lasts for the duration of the session, meaning once the browser is closed, the data is lost.

2. Same Storage Capacity: Both local and session storage offer similar storage limits (around 5-10 MB), but local storage is more suitable for persistent data, whereas session storage is temporary.

3. Better User Experience: Since local storage persists across multiple sessions, it provides a more seamless experience for users who want their inputted ingredients to be saved even if they close the application and return later.